### PR TITLE
Fix comment for Ctrl-b binding

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -145,7 +145,7 @@ export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
 # autosuggestions shortcuts
 bindkey "^f" forward-char           # Ctrl-f - forwards whole line
 bindkey "^w" forward-word           # Ctrl-w - forwards one word
-bindkey "^b" backward-word           # Ctrl-w - forwards one word
+bindkey "^b" backward-word           # Ctrl-b - move backward one word
 
 # n-history
 zle -N znt-history-widget


### PR DESCRIPTION
## Summary
- fix incorrect Ctrl-b comment in `zshrc`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687794bf0d6483239f5dc3b0eb1ae2ec