### PR TITLE
Add zoxide to dependency check

### DIFF
--- a/autozsh-checkup.sh
+++ b/autozsh-checkup.sh
@@ -16,5 +16,6 @@ check_command "git"
 check_command "curl"
 check_command "fzy"
 check_command "fzf"
+check_command "zoxide"
 
 echo -e "done!\n"


### PR DESCRIPTION
## Summary
- check for `zoxide` in `autozsh-checkup.sh`

## Testing
- `bash autozsh-checkup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877df71f3fc832393b9a9b86b59f253