### PR TITLE
Add reinstall check for existing oh-my-zsh

### DIFF
--- a/autozsh-install.sh
+++ b/autozsh-install.sh
@@ -26,6 +26,20 @@ else
     exit 1
 fi
 
+# check for previous oh-my-zsh installation
+if [[ -d "$HOME/.oh-my-zsh" ]]; then
+    echo "An existing oh-my-zsh installation was found at $HOME/.oh-my-zsh."
+    read -rp "Do you want to re-install (y/N)? " reinstall
+    reinstall=${reinstall,,}
+    if [[ "$reinstall" == "y" ]]; then
+        echo "Removing previous installation..."
+        rm -rf "$HOME/.oh-my-zsh"
+    else
+        echo "installation aborted."
+        exit 1
+    fi
+fi
+
 # run checkup
 ./autozsh-checkup.sh
 


### PR DESCRIPTION
## Summary
- prompt user when `.oh-my-zsh` already exists
- allow removing existing installation or aborting

## Testing
- `bash -n autozsh-install.sh`
- `bash -n autozsh-checkup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877df4bd3148323a7d8d4c0430d23c3